### PR TITLE
fix: add pagination to getAccountRoles

### DIFF
--- a/lib/accounts.mjs
+++ b/lib/accounts.mjs
@@ -25,13 +25,24 @@ export async function getAccountRoles(account) {
   });
 
   const token = await getToken();
-  const command = new ListAccountRolesCommand({
-    accessToken: token,
-    accountId: account.accountId,
-  });
-  const response = await client.send(command);
+  const roleList = [];
+  let nextToken;
 
-  const roles = response.roleList
+  do {
+    const input = {
+      accessToken: token,
+      accountId: account.accountId,
+    };
+    if (nextToken) {
+      input.nextToken = nextToken;
+    }
+    const command = new ListAccountRolesCommand(input);
+    const response = await client.send(command);
+    roleList.push(...response.roleList);
+    nextToken = response.nextToken;
+  } while (nextToken);
+
+  const roles = roleList
     .map((x) => {
       return {
         name: x.roleName,


### PR DESCRIPTION
ListAccountRoles API now paginates results, causing some roles to be missing. Added nextToken handling to fetch all pages, matching the pattern already used in listAccounts.

# Description

\`ListAccountRoles\` API started paginating results, causing only the first page of roles to be displayed. This resulted in missing roles for some
  accounts.

  ## Changes

  Added \`nextToken\` handling to \`getAccountRoles\` to fetch all pages, matching the pattern already used in \`listAccounts\`.

  ## Testing

  Verified locally that all roles now appear for affected accounts."
